### PR TITLE
Fix update command with RowsTerm.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,9 @@
 name: crystal-rethinkdb
-version: 0.1.7
+version: 0.1.8
 
 authors:
   - Kingsley Hendrickse <kingsley.hendrickse@gmail.com>
 
-crystal: 0.30.0
+crystal: 0.30.1
 
 license: MIT

--- a/spec/reql_spec.cr
+++ b/spec/reql_spec.cr
@@ -4,6 +4,8 @@ r.db("test").table_list.for_each do |name|
   r.db("test").table_drop(name)
 end.run(Fixtures::TestDB.conn)
 describe RethinkDB do
+  {{ run("./reql_spec_generator", "spec/rql_test/src/aggregation.yaml") }}
+  {{ run("./reql_spec_generator", "spec/rql_test/src/control.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/datum/array.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/datum/bool.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/datum/null.yaml") }}
@@ -12,6 +14,7 @@ describe RethinkDB do
   {{ run("./reql_spec_generator", "spec/rql_test/src/datum/string.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/datum/typeof.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/datum/uuid.yaml") }}
+  {{ run("./reql_spec_generator", "spec/rql_test/src/default.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/math_logic/add.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/math_logic/aliases.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/math_logic/div.yaml") }}
@@ -21,8 +24,6 @@ describe RethinkDB do
   {{ run("./reql_spec_generator", "spec/rql_test/src/math_logic/mod.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/math_logic/mul.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/math_logic/sub.yaml") }}
-  {{ run("./reql_spec_generator", "spec/rql_test/src/aggregation.yaml") }}
-  {{ run("./reql_spec_generator", "spec/rql_test/src/control.yaml") }}
-  {{ run("./reql_spec_generator", "spec/rql_test/src/default.yaml") }}
+  {{ run("./reql_spec_generator", "spec/rql_test/src/mutation/update.yaml") }}
   {{ run("./reql_spec_generator", "spec/rql_test/src/range.yaml") }}
 end

--- a/spec/rql_test/src/mutation/update.yaml
+++ b/spec/rql_test/src/mutation/update.yaml
@@ -4,14 +4,14 @@ tests:
 
     # Set up some data
     - py: tbl.insert([{'id':i} for i in xrange(100)])
-      js: |
-        tbl.insert(function(){
-            var res = []
-            for (var i = 0; i < 100; i++) {
-                res.push({id:i});
-            }
-            return res;
-        }())
+      # js: |
+      #   tbl.insert(function(){
+      #       var res = []
+      #       for (var i = 0; i < 100; i++) {
+      #           res.push({id:i});
+      #       }
+      #       return res;
+      #   }())
       rb: tbl.insert((0...100).map{ |i| { :id => i } })
       ot: ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100})
 
@@ -19,14 +19,14 @@ tests:
       ot: 100
 
     - py: tbl2.insert([{'id':i, 'foo':{'bar':i}} for i in xrange(100)])
-      js: |
-        tbl2.insert(function(){
-            var res = []
-            for (var i = 0; i < 100; i++) {
-                res.push({id:i,foo:{bar:i}});
-            }
-            return res;
-        }())
+      # js: |
+      #   tbl2.insert(function(){
+      #       var res = []
+      #       for (var i = 0; i < 100; i++) {
+      #           res.push({id:i,foo:{bar:i}});
+      #       }
+      #       return res;
+      #   }())
       rb: tbl2.insert((0...100).map{ |i| { :id => i, :foo => { :bar => i } } })
       ot: ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100})
 
@@ -36,7 +36,7 @@ tests:
     # Identity
     - py: tbl.get(12).update(lambda row:row)
       js: tbl.get(12).update(function(row) { return row; })
-      rb: tbl.get(12).update{ |row| row}
+      rb: tbl.get(12).update{ |row| row }
       ot: {'deleted':0.0,'replaced':0.0,'unchanged':1,'errors':0.0,'skipped':0.0,'inserted':0.0}
 
     # Soft durability point update
@@ -61,7 +61,7 @@ tests:
     - py: tbl.get(12).update(lambda row:{'a':row['id'] + 3}, durability='wrong')
       js: tbl.get(12).update(function(row) { return {'a':row('id').add(3)}; }, {durability:'wrong'})
       rb: tbl.get(12).update({ :durability => 'wrong' }) { |row| { :a => row[:id] + 3 } }
-      ot: err('ReqlQueryLogicError', 'Durability option `wrong` unrecognized (options are "hard" and "soft").', [0])
+      ot: err('ReqlQueryLogicError', 'Durability option `wrong` unrecognized \(options are "hard" and "soft"\).', [0])
 
     - cd: tbl.get(12)
       ot: {'id':12, 'a':14}

--- a/src/rethinkdb/api-global.cr
+++ b/src/rethinkdb/api-global.cr
@@ -110,6 +110,14 @@ module RethinkDB
     DatumTerm.new(TermType::DESC, [thing])
   end
 
+  def self.literal
+    DatumTerm.new(TermType::LITERAL)
+  end
+
+  def self.literal(any)
+    DatumTerm.new(TermType::LITERAL, [any])
+  end
+
   macro define_prefix_notation(*names)
     {% for name in names %}
       def self.{{name.id}}(target, *args, **kargs)

--- a/src/rethinkdb/api-grouped.cr
+++ b/src/rethinkdb/api-grouped.cr
@@ -145,9 +145,5 @@ module RethinkDB
     def distinct(options : Hash | NamedTuple)
       GroupedStreamTerm.new(TermType::DISTINCT, [self], options)
     end
-
-    def between(a, b, options : Hash | NamedTuple)
-      GroupedStreamTerm.new(TermType::BETWEEN, [self, a, b], options)
-    end
   end
 end

--- a/src/rethinkdb/api-row.cr
+++ b/src/rethinkdb/api-row.cr
@@ -2,12 +2,20 @@ require "./term"
 
 module RethinkDB
   class RowTerm < DatumTerm
-    def update(doc)
-      DatumTerm.new(TermType::UPDATE, [self, doc])
-    end
-
     def update
       DatumTerm.new(TermType::UPDATE, [self, Func.arity1 { |row| yield(row) }])
+    end
+
+    def update(doc, options : Hash | NamedTuple)
+      DatumTerm.new(TermType::UPDATE, [self, doc], options)
+    end
+
+    def update(doc, **options)
+      DatumTerm.new(TermType::UPDATE, [self, doc], options)
+    end
+
+    def update(options : Hash | NamedTuple)
+      DatumTerm.new(TermType::UPDATE, [self, Func.arity1 { |row| yield(row) }], options)
     end
 
     def replace(doc)

--- a/src/rethinkdb/api-rows.cr
+++ b/src/rethinkdb/api-rows.cr
@@ -2,12 +2,20 @@ require "./term"
 
 module RethinkDB
   class RowsTerm < StreamTerm
-    def update(doc)
-      DatumTerm.new(TermType::UPDATE, [self, doc])
-    end
-
     def update
       DatumTerm.new(TermType::UPDATE, [self, Func.arity1 { |row| yield(row) }])
+    end
+
+    def update(doc, options : Hash | NamedTuple)
+      DatumTerm.new(TermType::UPDATE, [self, doc], options)
+    end
+
+    def update(doc, **options)
+      DatumTerm.new(TermType::UPDATE, [self, doc], options)
+    end
+
+    def update(options : Hash | NamedTuple)
+      DatumTerm.new(TermType::UPDATE, [self, Func.arity1 { |row| yield(row) }], options)
     end
 
     def replace(doc)

--- a/src/rethinkdb/api-stream.cr
+++ b/src/rethinkdb/api-stream.cr
@@ -201,5 +201,21 @@ module RethinkDB
     def without(*fields)
       StreamTerm.new(TermType::WITHOUT, [self] + fields.to_a)
     end
+
+    def update
+      DatumTerm.new(TermType::UPDATE, [self, Func.arity1 { |row| yield(row) }])
+    end
+
+    def update(doc, options : Hash | NamedTuple)
+      DatumTerm.new(TermType::UPDATE, [self, doc], options)
+    end
+
+    def update(doc, **options)
+      DatumTerm.new(TermType::UPDATE, [self, doc], options)
+    end
+
+    def update(options : Hash | NamedTuple)
+      DatumTerm.new(TermType::UPDATE, [self, Func.arity1 { |row| yield(row) }], options)
+    end
   end
 end

--- a/src/rethinkdb/api-table.cr
+++ b/src/rethinkdb/api-table.cr
@@ -41,5 +41,17 @@ module RethinkDB
     def sample(number : Int32)
       DatumTerm.new(TermType::SAMPLE, [self, number])
     end
+
+    def [](key)
+      DatumTerm.new(TermType::BRACKET, [self, key])
+    end
+
+    def get_field(key)
+      DatumTerm.new(TermType::GET_FIELD, [self, key])
+    end
+
+    def nth(key)
+      DatumTerm.new(TermType::NTH, [self, key])
+    end
   end
 end


### PR DESCRIPTION

- Add update yaml tests.
- Add literal function manipulation for update's tests
- Comment javascript test code in yaml file because crystal doesn't support JS code with yaml literal syntax.