### PR TITLE
Use threadsafe Channel class

### DIFF
--- a/src/rethinkdb/connection.cr
+++ b/src/rethinkdb/connection.cr
@@ -103,7 +103,7 @@ module RethinkDB
       connect
       authorise(user, password)
 
-      @channels = {} of UInt64 => Channel::Unbuffered(String)
+      @channels = {} of UInt64 => Channel(String)
       @next_query_id = 1_u64
 
       spawn do
@@ -199,7 +199,7 @@ module RethinkDB
 
     class ResponseStream
       getter id : UInt64
-      @channel : Channel::Unbuffered(String)
+      @channel : Channel(String)
       @runopts : Hash(String, JSON::Any)
 
       def initialize(@conn : Connection, runopts)


### PR DESCRIPTION
In crystal-0.31.0, `Channel::Unbuffered` and `Channel::Buffered` have been merged, with unified behaviour under `Channel`. 

[See commit](https://github.com/crystal-lang/crystal/commit/ea4ae091c87da85acc9630306779bf448c54dae9#diff-28534fbfedc125e25dfc58732fa05c52)