### PR TITLE
Remove single value RowsTerm#get_all

### DIFF
--- a/src/rethinkdb/api-rows.cr
+++ b/src/rethinkdb/api-rows.cr
@@ -46,8 +46,8 @@ module RethinkDB
       RowsTerm.new(TermType::GET_ALL, [self] + args.to_a, kargs)
     end
 
-    def get_all(args, **kargs)
-      RowsTerm.new(TermType::GET_ALL, [self] + [args], kargs)
+    def get_all(args : Array, **kargs)
+      RowsTerm.new(TermType::GET_ALL, [self] + args, kargs)
     end
 
     def changes(**kargs)


### PR DESCRIPTION
As of v0.1.9, passing an array of values to `RowsTerms#get_all` nested the array. This produced query errors as the nested array became a key rather than a collection of values.

A simple fix is removing the nesting. Single value `RowsTerm#get_all` calls can be achieved through the existing splat method.

This won't build for crystal-0.31.0 as it does not include `Channel` changes