### PR TITLE
Threadsafety and Retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,8 @@
-# Crystal-RethinkDB
+# Crystal RethinkDB
 
 This is a [RethinkDB](http://rethinkdb.com/) Driver for the [Crystal Language](http://crystal-lang.org/).
 
-[![Build Status](https://travis-ci.org/kingsleyh/crystal-rethinkdb.svg?branch=master)](https://travis-ci.org/kingsleyh/crystal-rethinkdb) [![Crystal Version](https://img.shields.io/badge/crystal%20-0.31.1-brightgreen.svg)](https://crystal-lang.org/api/0.31.1/)
-
-### WARNING: This is only a basic driver a lot of functions are not implemented.
-
-## History
-
-This driver is mostly a copy of this project: [cubos/rethinkdb.cr](https://github.com/cubos/rethinkdb.cr) (quickly) updated to work for Crystal 26.1 (and now 0.28.0). It is designed to work with the rethinkdb V1_0 release and has the user authentication mechanism implemented which was taken from this project: [rethinkdb-lite](https://github.com/lbguilherme/rethinkdb-lite)
-
-Thanks to these great projects it was not too hard to create this one. Unfortunately those other 2 projects are not being maintained and the `rethinkdb.cr` project has more of the api implemented but the code is not as well structured as the newer `rethinkdb-lite` project. However `rethinkdb-lite` has a lot of missing functionality so I made the decision to fix up the original project and add in the authentication from the newer one.
-
-I will try to do more work on this library over time. Thanks to [Guilherme Bernal](https://github.com/lbguilherme) for his hard work on which this project is based.
-
-Thanks also to [Caspian Baska](https://github.com/caspiano) for all the awesome contributions.
+[![Build Status](https://travis-ci.org/aca-labs/crystal-rethinkdb.svg?branch=master)](https://travis-ci.org/aca-labs/crystal-rethinkdb) [![Crystal Version](https://img.shields.io/badge/crystal%20-0.33.0-brightgreen.svg)](https://crystal-lang.org/api/0.33.0/)
 
 ## Installation
 
@@ -22,16 +10,16 @@ Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
-  crystal-rethinkdb:
-    github: kingsleyh/crystal-rethinkdb
+  rethinkdb:
+    github: aca-labs/crystal-rethinkdb
 ```
 
 ## Usage
 
-This library is meant to be compatible with RethinkDB's Ruby API. Thus, all [official documentation](http://rethinkdb.com/api/ruby/) should be valid here. If you find something that behaves differently, please [open an issue](https://github.com/kingsleyh/crystal-rethinkdb/issues/new).
+This library is meant to be compatible with RethinkDB's Ruby API. Thus, all [official documentation](http://rethinkdb.com/api/ruby/) should be valid here. If you find something that behaves differently, please [open an issue](https://github.com/aca-labs/crystal-rethinkdb/issues/new).
 
 ```crystal
-require "crystal-rethinkdb"
+require "rethinkdb"
 include RethinkDB::Shortcuts
 
 # Let’s connect and create a table:
@@ -66,7 +54,7 @@ r.db('rethinkdb').table('users').insert({id: 'bob', password: 'secret'})
 ```
 
 ```crystal
-require "crystal-rethinkdb"
+require "rethinkdb"
 include RethinkDB::Shortcuts
 
 conn = r.connect(host: "localhost", db: "my_database", user: "bob", password: "secret")
@@ -81,9 +69,9 @@ Here are some more complex queries - mostly as a reminder to myself on how to do
 
 Something to note is that depending on the query you write you could get back one of these 3 things:
 
-* RethinkDB::QueryResult
-* RethinkDB:Cursor
-* RethinkDB::Array(RethinkDB::QueryResult)
+* `RethinkDB::QueryResult`
+* `RethinkDB:Cursor`
+* `RethinkDB::Array(RethinkDB::QueryResult)`
 
 ##### Inserting
 
@@ -198,11 +186,9 @@ def recreate_database
     end
 ```
 
-
-
 ## Contributing
 
-1. Fork it (<https://github.com/kingsleyh/crystal-rethinkdb/fork>)
+1. Fork it (<https://github.com/aca-labs/crystal-rethinkdb/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
@@ -211,4 +197,9 @@ def recreate_database
 ## Contributors
 
 - [kingsleyh](https://github.com/kingsleyh) Kingsley Hendrickse - creator, maintainer
-- [Caspiano](https://github.com/caspiano) Caspian Baska - contributor
+- [caspiano](https://github.com/caspiano) Caspian Baska - contributor, maintainer
+- [fenicks](https://github.com/fenicks) Christian Kakesa - contributor
+
+# Thanks
+
+- [Guilherme Bernal](https://github.com/lbguilherme) for his hard work on which this project is based.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,7 @@
-name: crystal-rethinkdb
-version: 0.1.10
+name: rethinkdb
+version: 0.2.0
+crystal: 0.33.0
+license: MIT
 
 dependencies:
   retriable:
@@ -9,7 +11,3 @@ dependencies:
 authors:
   - Kingsley Hendrickse <kingsley.hendrickse@gmail.com>
   - Caspian Baska <caspianbaska@gmail.com>
-
-crystal: 0.33.0
-
-license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb
-version: 0.2.3
+version: 0.2.4
 crystal: 0.33.0
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,15 @@
 name: crystal-rethinkdb
 version: 0.1.10
 
+dependencies:
+  retriable:
+    github: sija/retriable.cr
+    version: ~> 0.2.0
+
 authors:
   - Kingsley Hendrickse <kingsley.hendrickse@gmail.com>
+  - Caspian Baska <caspianbaska@gmail.com>
 
-crystal: 0.30.1
+crystal: 0.33.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb
-version: 0.2.1
+version: 0.2.2
 crystal: 0.33.0
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb
-version: 0.2.2
+version: 0.2.3
 crystal: 0.33.0
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb
-version: 0.2.0
+version: 0.2.1
 crystal: 0.33.0
 license: MIT
 

--- a/spec/reql_spec_generator.cr
+++ b/spec/reql_spec_generator.cr
@@ -50,7 +50,7 @@ puts "describe #{data["desc"].inspect} do"
 if tables = data["table_variable_name"]?
   puts
   tables.as_s.split(", ").map(&.split(" ")).flatten.each_with_index do |tablevar, i|
-    random_name = "test_#{Time.now.to_unix}_#{rand(10000)}_#{i + 1}"
+    random_name = "test_#{Time.utc.to_unix}_#{rand(10000)}_#{i + 1}"
     puts "  r.db(\"test\").table_create(#{random_name.inspect}).run(Fixtures::TestDB.conn)"
     puts "  #{tablevar} = r.db(\"test\").table(#{random_name.inspect})"
   end

--- a/spec/rethinkdb_spec.cr
+++ b/spec/rethinkdb_spec.cr
@@ -85,7 +85,7 @@ describe RethinkDB do
 
       cursor = r.table(table).changes.run Fixtures::TestDB.conn
       spawn do
-        cursor.each.with_index do |v, i|
+        cursor.each_with_index do |v, i|
           result << v
           break if i == number_of_queries - 1
         end
@@ -124,7 +124,7 @@ describe RethinkDB do
         e.to_s.should contain "Changefeed aborted"
       end
 
-      6.times.with_index do |i|
+      6.times do |i|
         r.table(table).get(pk).update({times: i + 1}).run Fixtures::TestDB.conn
       end
 

--- a/spec/rethinkdb_spec.cr
+++ b/spec/rethinkdb_spec.cr
@@ -8,13 +8,13 @@ describe RethinkDB do
 
   it "raises unknown user error" do
     expect_raises(RethinkDB::ReqlError::ReqlDriverError::ReqlAuthError, "error_code: 17, error: Unknown user") do
-      r.connect({host: Fixtures::TestDB.host, user: "owenfvoraewugbjbkv"})
+      r.connect(host: Fixtures::TestDB.host, user: "owenfvoraewugbjbkv")
     end
   end
 
   it "raises unknown user error" do
     expect_raises(RethinkDB::ReqlError::ReqlDriverError::ReqlAuthError, "error_code: 12, error: Wrong password") do
-      r.connect({host: Fixtures::TestDB.host, user: "admin", password: "incorrect"})
+      r.connect(host: Fixtures::TestDB.host, user: "admin", password: "incorrect")
     end
   end
 

--- a/spec/rql_test/src/selection.yaml
+++ b/spec/rql_test/src/selection.yaml
@@ -88,10 +88,10 @@ tests:
 
     # db and table name validation
     - cd: r.db('%')
-      ot: err("ReqlQueryLogicError", 'Database name `%` invalid (Use A-Za-z0-9_ only).', [0])
+      ot: err("ReqlQueryLogicError", 'Database name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).', [0])
 
     - cd: r.db('test').table('%')
-      ot: err("ReqlQueryLogicError", 'Table name `%` invalid (Use A-Za-z0-9_ only).', [0])
+      ot: err("ReqlQueryLogicError", 'Table name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).', [0])
 
     # Access a table from default db
     - cd: tbl.count()

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -63,13 +63,13 @@ module Fixtures
     @@host = uninitialized String
 
     begin
-      r.connect({host: "rethinkdb"}).close
+      r.connect(host: "rethinkdb").close
       @@host = "rethinkdb"
     rescue
     end
 
     begin
-      r.connect({host: "localhost"}).close
+      r.connect(host: "localhost").close
       @@host = "localhost"
     rescue
     end
@@ -86,7 +86,7 @@ module Fixtures
     end
 
     def self.conn
-      r.connect({host: host})
+      r.connect(host: host)
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -43,10 +43,12 @@ module Generators
           "array"  => Generators.random_array,
           "object" => Generators.random_hash,
         }
-        response = r.json(document.to_json).do { |value|
+
+        r.json(document.to_json).do { |value|
           r.table(table).insert(value, return_changes: true)
         }.run(Fixtures::TestDB.conn)
       end
+
       begin
         block.call(table)
       ensure
@@ -54,7 +56,6 @@ module Generators
       end
     end
   end
-
 end
 
 module Fixtures

--- a/src/crystal-rethinkdb.cr
+++ b/src/crystal-rethinkdb.cr
@@ -11,11 +11,7 @@ module RethinkDB
     end
   end
 
-  def self.connect(options)
-    Connection.new(options)
-  end
-
   def self.connect(**options)
-    Connection.new(options)
+    Connection.new(**options)
   end
 end

--- a/src/rethinkdb.cr
+++ b/src/rethinkdb.cr
@@ -1,0 +1,17 @@
+require "./rethinkdb/*"
+
+module RethinkDB
+  module Shortcuts
+    def r
+      RethinkDB
+    end
+
+    def r(any)
+      r.expr(any)
+    end
+  end
+
+  def self.connect(**options)
+    Connection.new(**options)
+  end
+end

--- a/src/rethinkdb/api-datum.cr
+++ b/src/rethinkdb/api-datum.cr
@@ -397,5 +397,13 @@ module RethinkDB
     def between(a, b, options : Hash | NamedTuple)
       DatumTerm.new(TermType::BETWEEN, [self, a, b], options)
     end
+
+    def keys
+      DatumTerm.new(TermType::KEYS, [self])
+    end
+
+    def values
+      DatumTerm.new(TermType::VALUES, [self])
+    end
   end
 end

--- a/src/rethinkdb/api-datum.cr
+++ b/src/rethinkdb/api-datum.cr
@@ -405,5 +405,9 @@ module RethinkDB
     def values
       DatumTerm.new(TermType::VALUES, [self])
     end
+
+    def date
+      DatumTerm.new(TermType::DATE, [self])
+    end
   end
 end

--- a/src/rethinkdb/api-datum.cr
+++ b/src/rethinkdb/api-datum.cr
@@ -26,8 +26,20 @@ module RethinkDB
       DatumTerm.new(TermType::MERGE, [self, Func.arity1 { |row| yield(row) }])
     end
 
+    def set_difference(value)
+      DatumTerm.new(TermType::SET_DIFFERENCE, [self, value])
+    end
+
+    def set_intersection(value)
+      DatumTerm.new(TermType::SET_INTERSECTION, [self, value])
+    end
+
     def set_insert(value)
       DatumTerm.new(TermType::SET_INSERT, [self, value])
+    end
+
+    def set_union(value)
+      DatumTerm.new(TermType::SET_UNION, [self, value])
     end
 
     def default(value)

--- a/src/rethinkdb/api-datum.cr
+++ b/src/rethinkdb/api-datum.cr
@@ -393,7 +393,7 @@ module RethinkDB
     def between(a, b)
       DatumTerm.new(TermType::BETWEEN, [self, a, b])
     end
-    
+
     def between(a, b, options : Hash | NamedTuple)
       DatumTerm.new(TermType::BETWEEN, [self, a, b], options)
     end

--- a/src/rethinkdb/api-datum.cr
+++ b/src/rethinkdb/api-datum.cr
@@ -238,6 +238,10 @@ module RethinkDB
       DatumTerm.new(TermType::SPLICE_AT, [self, index, array])
     end
 
+    def delete
+      DatumTerm.new(TermType::DELETE, [self])
+    end
+
     def delete_at(index)
       DatumTerm.new(TermType::DELETE_AT, [self, index])
     end

--- a/src/rethinkdb/api-datum.cr
+++ b/src/rethinkdb/api-datum.cr
@@ -386,8 +386,12 @@ module RethinkDB
       end
     end
 
-    def changes(**kargs)
-      ChangesTerm.new(TermType::CHANGES, [self], kargs)
+    def changes
+      ChangesTerm.new(TermType::CHANGES, [self])
+    end
+
+    def changes(options : Hash | NamedTuple)
+      ChangesTerm.new(TermType::CHANGES, [self], options)
     end
 
     def between(a, b)

--- a/src/rethinkdb/api-db.cr
+++ b/src/rethinkdb/api-db.cr
@@ -53,5 +53,9 @@ module RethinkDB
     def table_list
       DatumTerm.new(TermType::TABLE_LIST, [self])
     end
+
+    def grant(username, options : Hash | NamedTuple)
+      DatumTerm.new(TermType::GRANT, [self, username, options])
+    end
   end
 end

--- a/src/rethinkdb/api-row.cr
+++ b/src/rethinkdb/api-row.cr
@@ -30,8 +30,12 @@ module RethinkDB
       DatumTerm.new(TermType::DELETE, [self])
     end
 
-    def changes(**kargs)
-      ChangesTerm.new(TermType::CHANGES, [self], kargs)
+    def changes
+      ChangesTerm.new(TermType::CHANGES, [self])
+    end
+
+    def changes(options : Hash | NamedTuple)
+      ChangesTerm.new(TermType::CHANGES, [self], options)
     end
   end
 end

--- a/src/rethinkdb/api-rows.cr
+++ b/src/rethinkdb/api-rows.cr
@@ -50,8 +50,12 @@ module RethinkDB
       RowsTerm.new(TermType::GET_ALL, [self] + args, kargs)
     end
 
-    def changes(**kargs)
-      ChangesTerm.new(TermType::CHANGES, [self], kargs)
+    def changes
+      ChangesTerm.new(TermType::CHANGES, [self])
+    end
+
+    def changes(options : Hash | NamedTuple)
+      ChangesTerm.new(TermType::CHANGES, [self], options)
     end
   end
 end

--- a/src/rethinkdb/api-rows.cr
+++ b/src/rethinkdb/api-rows.cr
@@ -57,5 +57,25 @@ module RethinkDB
     def changes(options : Hash | NamedTuple)
       ChangesTerm.new(TermType::CHANGES, [self], options)
     end
+
+    def count
+      DatumTerm.new(TermType::COUNT, [self])
+    end
+
+    def count(value)
+      DatumTerm.new(TermType::COUNT, [self, value])
+    end
+
+    def count
+      DatumTerm.new(TermType::COUNT, [self, Func.arity1 { |row| yield(row) }])
+    end
+
+    def slice(start)
+      RowsTerm.new(TermType::SLICE, [self, start])
+    end
+
+    def slice(start, size)
+      RowsTerm.new(TermType::SLICE, [self, start, size])
+    end
   end
 end

--- a/src/rethinkdb/api-stream.cr
+++ b/src/rethinkdb/api-stream.cr
@@ -217,5 +217,9 @@ module RethinkDB
     def update(options : Hash | NamedTuple)
       DatumTerm.new(TermType::UPDATE, [self, Func.arity1 { |row| yield(row) }], options)
     end
+
+    def merge
+      DatumTerm.new(TermType::MERGE, [self, Func.arity1 { |row| yield(row) }])
+    end
   end
 end

--- a/src/rethinkdb/api-stream.cr
+++ b/src/rethinkdb/api-stream.cr
@@ -221,5 +221,13 @@ module RethinkDB
     def merge
       DatumTerm.new(TermType::MERGE, [self, Func.arity1 { |row| yield(row) }])
     end
+
+    def changes
+      ChangesTerm.new(TermType::CHANGES, [self])
+    end
+
+    def changes(options : Hash | NamedTuple)
+      ChangesTerm.new(TermType::CHANGES, [self], options)
+    end
   end
 end

--- a/src/rethinkdb/api-table.cr
+++ b/src/rethinkdb/api-table.cr
@@ -38,6 +38,10 @@ module RethinkDB
       DatumTerm.new(TermType::INDEX_LIST, [self])
     end
 
+    def index_drop(name)
+      DatumTerm.new(TermType::INDEX_DROP, [self, name])
+    end
+
     def sample(number : Int32)
       DatumTerm.new(TermType::SAMPLE, [self, number])
     end

--- a/src/rethinkdb/auth.cr
+++ b/src/rethinkdb/auth.cr
@@ -1,0 +1,65 @@
+require "./message"
+
+module RethinkDB
+  # Data formats for RethinkDB connection authentication flow
+  private module Auth
+    struct Message1 < Message
+      getter protocol_version : Int32
+      getter authentication_method : String
+      getter authentication : String
+
+      def initialize(
+        @protocol_version : Int32,
+        @authentication_method : String,
+        @authentication : String
+      )
+      end
+    end
+
+    struct MessageErrorResponse < Message
+      getter error : String
+      getter error_code : Int64
+      getter success : Bool
+    end
+
+    struct Message1SuccessResponse < Message
+      getter authentication : String
+      getter success : Bool
+
+      def r
+        value_for("r")
+      end
+
+      def s
+        Base64.decode(value_for("s"))
+      end
+
+      def i
+        value_for("i").to_i
+      end
+
+      private def value_for(target : String)
+        authentication.split(",").find(if_none: "") { |f|
+          f.starts_with?("#{target}=")
+        }.split("#{target}=").last
+      end
+    end
+
+    struct Message3 < Message
+      getter authentication : String
+
+      def initialize(nonce : String, encoded_password : String)
+        @authentication = "c=biws,r=#{nonce},p=#{encoded_password}"
+      end
+    end
+
+    struct Message3SuccessResponse < Message
+      getter authentication : String
+      getter success : Bool
+
+      def v
+        authentication.split("v=").last
+      end
+    end
+  end
+end

--- a/src/rethinkdb/connection.cr
+++ b/src/rethinkdb/connection.cr
@@ -1,9 +1,11 @@
+require "json"
+require "retriable"
 require "socket"
 require "socket/tcp_socket"
-require "json"
-require "./serialization"
+
 require "./constants"
 require "./crypto"
+require "./serialization"
 
 module RethinkDB
   class ConnectionException < Exception
@@ -17,8 +19,8 @@ module RethinkDB
       success: Bool
     )
 
-    def self._from_json(json)
-      ConnectionResponse.from_json(json.not_nil!)
+    def self.from_json(json)
+      super(json.not_nil!)
     rescue error
       raise ConnectionException.new(json)
     end
@@ -122,7 +124,7 @@ module RethinkDB
       protocol_version_bytes = Bytes.new(4)
       IO::ByteFormat::LittleEndian.encode(0x34c2bdc3_u32, protocol_version_bytes)
       write(protocol_version_bytes)
-      response = ConnectionResponse._from_json(read)
+      response = ConnectionResponse.from_json(read)
       raise ConnectionException.new("Connection could not be established: #{response}") if response.success != true
       response
     end

--- a/src/rethinkdb/connection.cr
+++ b/src/rethinkdb/connection.cr
@@ -414,26 +414,44 @@ module RethinkDB
   class Cursor
     include Iterator(QueryResult)
 
+    private property index : Int32 = 0
+    private property stopped : Bool = false
+    private property response
+    private getter stream
+
     def initialize(@stream : Connection::ResponseStream, @response : Connection::Response)
-      @index = 0
+    end
+
+    def stop
+      self.stopped = true
+      stream.conn.delete_channel(stream.id).try &.close
+      super
     end
 
     def fetch_next
-      @response = @stream.query_continue
-      @index = 0
+      self.response = stream.query_continue
+      self.index = 0
 
-      unless @response.t == ResponseType::SUCCESS_SEQUENCE || @response.t == ResponseType::SUCCESS_PARTIAL
-        raise ReqlDriverError.new("Expected SUCCESS_SEQUENCE or SUCCESS_PARTIAL but got #{@response.t}")
+      unless response.t.in? [ResponseType::SUCCESS_SEQUENCE, ResponseType::SUCCESS_PARTIAL]
+        raise ReqlDriverError.new("Expected SUCCESS_SEQUENCE or SUCCESS_PARTIAL but got #{response.t}")
       end
+
+      true
+    rescue e
+      # Do not raise after iteration stonpped
+      raise e unless stopped
+
+      false
     end
 
     def next
-      while @index == @response.r.size
-        return stop if @response.t == ResponseType::SUCCESS_SEQUENCE
-        fetch_next
+      return stop if stopped
+      while index == response.r.size
+        return stop if response.t == ResponseType::SUCCESS_SEQUENCE
+        return stop unless fetch_next
       end
 
-      value = @response.r[@index]
+      value = response.r[index]
       @index += 1
       value
     end

--- a/src/rethinkdb/cursor.cr
+++ b/src/rethinkdb/cursor.cr
@@ -1,4 +1,5 @@
 require "./constants"
+require "./serialization"
 
 module RethinkDB
   class Cursor

--- a/src/rethinkdb/cursor.cr
+++ b/src/rethinkdb/cursor.cr
@@ -1,0 +1,48 @@
+require "./constants"
+
+module RethinkDB
+  class Cursor
+    include Iterator(QueryResult)
+
+    private property index : Int32 = 0
+    private property stopped : Bool = false
+    private property response
+    private getter stream
+
+    def initialize(@stream : Connection::ResponseStream, @response : Connection::Response)
+    end
+
+    def stop
+      self.stopped = true
+      stream.conn.delete_channel(stream.id).try &.close
+      super
+    end
+
+    def fetch_next
+      self.response = stream.query_continue
+      self.index = 0
+
+      unless response.t.in? [ResponseType::SUCCESS_SEQUENCE, ResponseType::SUCCESS_PARTIAL]
+        raise ReqlDriverError.new("Expected SUCCESS_SEQUENCE or SUCCESS_PARTIAL but got #{response.t}")
+      end
+
+      true
+    rescue e
+      # Do not raise after iteration stonpped
+      raise e unless stopped
+      false
+    end
+
+    def next
+      return stop if stopped
+      while index == response.r.size
+        return stop if response.t == ResponseType::SUCCESS_SEQUENCE
+        return stop unless fetch_next
+      end
+
+      value = response.r[index]
+      @index += 1
+      value
+    end
+  end
+end

--- a/src/rethinkdb/error.cr
+++ b/src/rethinkdb/error.cr
@@ -28,4 +28,7 @@ module RethinkDB
 
   class ReqlOpFailedError < Exception
   end
+
+  class ConnectionException < Exception
+  end
 end

--- a/src/rethinkdb/message.cr
+++ b/src/rethinkdb/message.cr
@@ -1,0 +1,9 @@
+require "json"
+
+module RethinkDB
+  # :nodoc:
+  private abstract struct Message
+    include JSON::Serializable
+    include JSON::Serializable::Strict
+  end
+end

--- a/src/rethinkdb/term.cr
+++ b/src/rethinkdb/term.cr
@@ -125,11 +125,15 @@ module RethinkDB
 
   class ChangesTerm < Term
     def run(conn, **runopts) : Cursor
-      conn.query_changefeed(self, **runopts)
+      conn.query_changefeed(self, runopts)
     end
 
     def run(conn) : Cursor
       conn.query_changefeed(self, {} of String => String)
+    end
+
+    def run(conn, runopts : Hash | NamedTuple)
+      conn.query_cursor(self, runopts)
     end
   end
 


### PR DESCRIPTION
This is still a WIP, interested in your thoughts @kingsleyh.

I'm yet to write tests for the retry, and cursor cancellation logic. I'm also more than happy to split this into multiple PRs 🙂

# Changes

- `RethinkDB::Connection.new` accepts explicit arguments, this improves documentation and usability.
- Updated a `Time.now` to `Time.utc`
- Added retry `RethinkDB::Connection`, this can be disabled by initialising with `max_retry_attempts: 0`
- Optimized `send_query`. Socket only flushes after the entire query is written
- Query/response objects are now structs. This provides a debatable efficiency boost
- `Cursor#stop` cleans up the connection, and stops iteration

# Fixes

- `RethinkDB::Connection` is now threadsafe
- update specs for `rethinkdb v2.4`