### PR TITLE
fix: reconnects

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: rethinkdb
-version: 0.2.0
-crystal: 0.34.0
+version: 0.2.1
+crystal: ~> 0.34
 license: MIT
 
 dependencies:

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,12 @@
 require "spec"
+require "log"
+
 require "../src/crystal-rethinkdb"
 include RethinkDB::Shortcuts
+
+Spec.before_suite do
+  ::Log.setup "*", Log::Severity::Debug
+end
 
 module Generators
   @@i = 0

--- a/src/rethinkdb/crypto.cr
+++ b/src/rethinkdb/crypto.cr
@@ -40,5 +40,5 @@ end
 def sha256(data)
   digest = OpenSSL::Digest.new("SHA256")
   digest.update(data)
-  digest.digest
+  digest.final
 end


### PR DESCRIPTION
Add general reconnect logic.
The blocking `read_bytes` in `read_loop` will hang if a fatal socket error occurs.
Closing the socket after a failed `write` will cause `read_loop` to reconnect.