### PR TITLE
Crystal v1.0.0 enum compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a [RethinkDB](http://rethinkdb.com/) Driver for the [Crystal Language](http://crystal-lang.org/).
 
-[![Build Status](https://travis-ci.org/kingsleyh/crystal-rethinkdb.svg?branch=master)](https://travis-ci.org/kingsleyh/crystal-rethinkdb) [![Crystal Version](https://img.shields.io/badge/crystal%20-0.35.1-brightgreen.svg)](https://crystal-lang.org/api/0.35.1/)
+[![Build Status](https://travis-ci.org/kingsleyh/crystal-rethinkdb.svg?branch=master)](https://travis-ci.org/kingsleyh/crystal-rethinkdb) [![Crystal Version](https://img.shields.io/badge/crystal%20-1.0.0-brightgreen.svg)](https://crystal-lang.org/api/1.0.0/)
 
 ## Installation
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: rethinkdb
-version: 0.2.1
-crystal: ~> 0.34
+version: 0.2.2
+crystal: ">= 0.34"
 license: MIT
 
 dependencies:

--- a/spec/reql_spec_generator.cr
+++ b/spec/reql_spec_generator.cr
@@ -49,7 +49,7 @@ data = YAML.parse(yaml_fixes File.read(ARGV[0]))
 puts "describe #{data["desc"].inspect} do"
 if tables = data["table_variable_name"]?
   puts
-  tables.as_s.split(", ").map(&.split(" ")).flatten.each_with_index do |tablevar, i|
+  tables.as_s.split(", ").flat_map(&.split(' ')).each_with_index do |tablevar, i|
     random_name = "test_#{Time.utc.to_unix}_#{rand(10000)}_#{i + 1}"
     puts "  r.db(\"test\").table_create(#{random_name.inspect}).run(Fixtures::TestDB.conn)"
     puts "  #{tablevar} = r.db(\"test\").table(#{random_name.inspect})"

--- a/src/rethinkdb/serialization.cr
+++ b/src/rethinkdb/serialization.cr
@@ -8,7 +8,7 @@ class Array(T)
   def to_reql
     JSON.parse([
       RethinkDB::TermType::MAKE_ARRAY.to_i64,
-      map { |x| x.to_reql },
+      map &.to_reql,
     ].to_json)
   end
 end
@@ -17,7 +17,7 @@ struct Tuple
   def to_reql
     JSON.parse([
       RethinkDB::TermType::MAKE_ARRAY.to_i64,
-      to_a.map { |x| x.to_reql },
+      to_a.map &.to_reql,
     ].to_json)
   end
 end


### PR DESCRIPTION
Enums serialise to strings by default as of 1.0.0 (see [#10431](https://github.com/crystal-lang/crystal/pull/10431)).
This PR maintains backwards-compatibility. 