### PR TITLE
perf: strip double parses

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,12 +1,12 @@
 name: rethinkdb
-version: 0.2.2
+version: 0.2.3
 crystal: ">= 0.34"
 license: MIT
 
 dependencies:
   retriable:
     github: sija/retriable.cr
-    version: ~> 0.2.0
+    version: ~> 0.2
 
 authors:
   - Kingsley Hendrickse <kingsley.hendrickse@gmail.com>

--- a/src/rethinkdb/connection.cr
+++ b/src/rethinkdb/connection.cr
@@ -346,9 +346,7 @@ module RethinkDB
       end
 
       private def send_query(type : QueryType, *rest)
-        if id == 0
-          raise ReqlDriverError.new("Bug: Using already finished stream.")
-        end
+        raise ReqlDriverError.new("Bug: Using already finished stream.") if id.zero?
 
         query_slice = ({type.value} + rest).to_json.to_slice
         conn.try_write do

--- a/src/rethinkdb/constants.cr
+++ b/src/rethinkdb/constants.cr
@@ -1,3 +1,5 @@
+require "json"
+
 module RethinkDB
   enum Version
     V0_1 = 0x3f61ba36
@@ -237,5 +239,9 @@ module RethinkDB
     BIT_NOT            = 194
     BIT_SAL            = 195
     BIT_SAR            = 196
+
+    def to_reql
+      ::JSON::Any.new(value.to_i64)
+    end
   end
 end

--- a/src/rethinkdb/term.cr
+++ b/src/rethinkdb/term.cr
@@ -5,11 +5,11 @@ module RethinkDB
     @reql : JSON::Any
 
     def initialize(any : JSON::Any)
-      @reql = JSON.parse(any.to_json)
+      @reql = any
     end
 
     def initialize(type : RethinkDB::TermType)
-      @reql = JSON.parse([type.to_i64].to_json)
+      @reql = ::JSON.parse([type.to_i64].to_json)
     end
 
     def initialize(type : RethinkDB::TermType, args : Array)

--- a/src/rethinkdb/term.cr
+++ b/src/rethinkdb/term.cr
@@ -9,24 +9,22 @@ module RethinkDB
     end
 
     def initialize(type : RethinkDB::TermType)
-      @reql = ::JSON.parse([type.to_i64].to_json)
+      @reql = ::JSON::Any.new([type.to_reql])
     end
 
     def initialize(type : RethinkDB::TermType, args : Array)
-      args = args.map(&.to_reql.as(JSON::Any))
-      @reql = JSON.parse([
-        type.to_i64,
-        args,
-      ].to_json)
+      @reql = ::JSON::Any.new([
+        type.to_reql,
+        ::JSON::Any.new(args.map(&.to_reql.as(JSON::Any))),
+      ])
     end
 
     def initialize(type : RethinkDB::TermType, args : Array, options)
-      args = args.map(&.to_reql.as(JSON::Any))
-      @reql = JSON.parse([
-        type.to_i64,
-        args,
+      @reql = ::JSON::Any.new([
+        type.to_reql,
+        ::JSON::Any.new(args.map(&.to_reql.as(JSON::Any))),
         options.to_reql,
-      ].to_json)
+      ])
     end
 
     def to_reql


### PR DESCRIPTION
There's a terrible pattern across this code base where values are serialised to JSON before being deserialised into `JSON::Any`... 
This PR eliminates the pattern in favour of a type-safe and more performant approach of actually marshalling values into `JSON::Any` values.