### PR TITLE
fix(connection): reconnect on write fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 on:
   push:
+  pull_request:
   schedule:
-    - cron: "0 0 * * *" # Nightly at midnight
+    - cron: "0 0 * * 1" # Midnight monday
 
 jobs:
   style:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb
-version: 0.3.0
+version: 0.3.1
 crystal: ">= 0.35.1"
 license: MIT
 


### PR DESCRIPTION
Reconnections were only triggered on failed reads due to connection errors, but not on writes.

This PR remedies that.